### PR TITLE
FieldValidator should be able to be subclassed from outside of the module

### DIFF
--- a/Sources/VaporForms/Validator.swift
+++ b/Sources/VaporForms/Validator.swift
@@ -5,14 +5,22 @@ import Node
   Inherit from this class to implement a field validator. A field validator
   takes a single value of type `T` and returns a `FieldValidationResult`.
 */
-public class FieldValidator<T> {
+open class FieldValidator<T> {
+
+  /**
+     This initializer needs to be present until the following swift bug
+     gets fixed, otherwise we can't subclass from this module
+     https://bugs.swift.org/browse/SR-2295
+  */
+  public init() {}
+
   /**
     Validate your value. If the validation was successful, return
     `.success(value)`. Otherwise, return
     `.failure([validationFailed(message: String)])` where the message is a
     string to be displayed to end-users of the form.
   */
-  public func validate(input value: T) -> FieldValidationResult {
+  open func validate(input value: T) -> FieldValidationResult {
     return .success(Node(nil))
   }
 }


### PR DESCRIPTION
Change the FieldValidator class to be open, in order to be subclassed.

Also added a public init() due to the following Swift bug https://bugs.swift.org/browse/SR-2295