### PR TITLE
Added support for Multipart strings 

### DIFF
--- a/Sources/VaporForms/Fieldset.swift
+++ b/Sources/VaporForms/Fieldset.swift
@@ -56,11 +56,13 @@ public struct Fieldset {
     fields.forEach { fieldName, fieldDefinition in
       // For each field, see if there's a matching value in the Content
       // Fail if no matching value for a required field
-        var value: Node
+        let value: Node
         if let nodeValue = content[fieldName] as? Node {
             value = nodeValue
-        } else if let multipart = content[fieldName] as? Multipart,
-            case let .input(string) = multipart {
+        } else if
+            let multipart = content[fieldName] as? Multipart,
+            case let .input(string) = multipart
+        {
             value = Node(string)
         } else {
             if requiredFieldNames.contains(fieldName) {
@@ -68,7 +70,6 @@ public struct Fieldset {
             }
             return
         }
-        
         
       // Store the passed-in value to be returned later
       values[fieldName] = value

--- a/Sources/VaporForms/Fieldset.swift
+++ b/Sources/VaporForms/Fieldset.swift
@@ -56,12 +56,20 @@ public struct Fieldset {
     fields.forEach { fieldName, fieldDefinition in
       // For each field, see if there's a matching value in the Content
       // Fail if no matching value for a required field
-      guard let value = content[fieldName] as? Node else {
-        if requiredFieldNames.contains(fieldName) {
-          errors[fieldName].append(.requiredMissing)
+        var value: Node
+        if let nodeValue = content[fieldName] as? Node {
+            value = nodeValue
+        } else if let multipart = content[fieldName] as? Multipart,
+            case let .input(string) = multipart {
+            value = Node(string)
+        } else {
+            if requiredFieldNames.contains(fieldName) {
+                errors[fieldName].append(.requiredMissing)
+            }
+            return
         }
-        return
-      }
+        
+        
       // Store the passed-in value to be returned later
       values[fieldName] = value
       // Now try to validate it against the field

--- a/Sources/VaporForms/Fieldset.swift
+++ b/Sources/VaporForms/Fieldset.swift
@@ -56,20 +56,20 @@ public struct Fieldset {
     fields.forEach { fieldName, fieldDefinition in
       // For each field, see if there's a matching value in the Content
       // Fail if no matching value for a required field
-        let value: Node
-        if let nodeValue = content[fieldName] as? Node {
-            value = nodeValue
-        } else if
-            let multipart = content[fieldName] as? Multipart,
-            case let .input(string) = multipart
+      let value: Node
+      if let nodeValue = content[fieldName] as? Node {
+        value = nodeValue
+      } else if
+        let multipart = content[fieldName] as? Multipart,
+        case let .input(string) = multipart
         {
-            value = Node(string)
+          value = Node(string)
         } else {
-            if requiredFieldNames.contains(fieldName) {
-                errors[fieldName].append(.requiredMissing)
-            }
-            return
+          if requiredFieldNames.contains(fieldName) {
+            errors[fieldName].append(.requiredMissing)
         }
+          return
+      }
         
       // Store the passed-in value to be returned later
       values[fieldName] = value

--- a/Sources/VaporForms/Fieldset.swift
+++ b/Sources/VaporForms/Fieldset.swift
@@ -62,15 +62,15 @@ public struct Fieldset {
       } else if
         let multipart = content[fieldName] as? Multipart,
         case let .input(string) = multipart
-        {
-          value = Node(string)
-        } else {
-          if requiredFieldNames.contains(fieldName) {
-            errors[fieldName].append(.requiredMissing)
+      {
+        value = Node(string)
+      } else {
+        if requiredFieldNames.contains(fieldName) {
+          errors[fieldName].append(.requiredMissing)
         }
-          return
+        return
       }
-        
+      
       // Store the passed-in value to be returned later
       values[fieldName] = value
       // Now try to validate it against the field

--- a/Tests/VaporFormsTests/VaporFormsTests.swift
+++ b/Tests/VaporFormsTests/VaporFormsTests.swift
@@ -702,101 +702,88 @@ class VaporFormsTests: XCTestCase {
     } catch { XCTFail() }
   }
     
-    func testSampleLoginFormWithMultipart() {
-        // Test a simple login form which validates against a credential store.
-        struct LoginForm: Form {
-            let username: String
-            let password: String
-            static let fieldset = Fieldset([
-                "username": StringField(label: "Username"),
-                "password": StringField(label: "Password"),
-                ], requiring: ["username", "password"]) { fieldset in
-                    let credentialStore = [
-                        (username: "user1", password: "pass1"),
-                        (username: "user2", password: "pass2"),
-                        (username: "user3", password: "pass3"),
-                        ]
-                    if (credentialStore.filter {
-                        $0.username == fieldset.values["username"]!.string! && $0.password == fieldset.values["password"]!.string!
-                        }.isEmpty) {
-                        fieldset.errors["password"].append(FieldError.validationFailed(message: "Invalid password"))
-                    }
-            }
-            internal init(validatedData: [String: Node]) throws {
-                username = validatedData["username"]!.string!
-                password = validatedData["password"]!.string!
-            }
+  func testSampleLoginFormWithMultipart() {
+    // Test a simple login form which validates against a credential store.
+    struct LoginForm: Form {
+      let username: String
+      let password: String
+      static let fieldset = Fieldset([
+        "username": StringField(label: "Username"),
+        "password": StringField(label: "Password"),
+      ], requiring: ["username", "password"]) { fieldset in
+        let credentialStore = [
+          (username: "user1", password: "pass1"),
+          (username: "user2", password: "pass2"),
+          (username: "user3", password: "pass3"),
+        ]
+        if (credentialStore.filter {
+          $0.username == fieldset.values["username"]!.string! && $0.password == fieldset.values["password"]!.string!
+        }.isEmpty) {
+          fieldset.errors["password"].append(FieldError.validationFailed(message: "Invalid password"))
         }
-        // Try and log in incorrectly
-        do {
-            
-            let boundary = "~~vapor-forms~~"
-            var body = "--" + boundary + "\r\n"
-            body += "Content-Disposition: form-data; name=\"username\"\r\n"
-            body += "\r\n"
-            body += "user1\r\n"
-            body += "--" + boundary + "\r\n"
-            body += "Content-Disposition: form-data; name=\"password\"\r\n"
-            body += "\r\n"
-            body += "notmypassword\r\n"
-            body += "--" + boundary + "\r\n"
-            
-            
-            let parsedBoundary = try Multipart.parseBoundary(contentType: "multipart/form-data; charset=utf-8; boundary=\(boundary)")
-            let multipart = Multipart.parse(body.bytes, boundary: parsedBoundary)
-            
-            let postData = Content()
-            
-            postData.append { (indexes: [PathIndex]) -> Polymorphic? in
-                guard let first = indexes.first else { return nil }
-                if let string = first as? String {
-                    return multipart[string]
-                } else if let int = first as? Int {
-                    return multipart["\(int)"]
-                } else {
-                    return nil
-                }
-            }
-            
-            let _ = try LoginForm(validating: postData)
-            XCTFail()
-        } catch FormError.validationFailed(let fieldset) {
-            XCTAssertEqual(fieldset.errors["password"][0].localizedDescription, "Invalid password")
-        } catch { XCTFail() }
-        // Try and log in correctly
-        do {
-            
-            let boundary = "~~vapor-forms~~"
-            var body = "--" + boundary + "\r\n"
-            body += "Content-Disposition: form-data; name=\"username\"\r\n"
-            body += "\r\n"
-            body += "user1\r\n"
-            body += "--" + boundary + "\r\n"
-            body += "Content-Disposition: form-data; name=\"password\"\r\n"
-            body += "\r\n"
-            body += "pass1\r\n"
-            body += "--" + boundary + "\r\n"
-            
-            
-            let parsedBoundary = try Multipart.parseBoundary(contentType: "multipart/form-data; charset=utf-8; boundary=\(boundary)")
-            let multipart = Multipart.parse(body.bytes, boundary: parsedBoundary)
-            
-            let postData = Content()
-            
-            postData.append { (indexes: [PathIndex]) -> Polymorphic? in
-                guard let first = indexes.first else { return nil }
-                if let string = first as? String {
-                    return multipart[string]
-                } else if let int = first as? Int {
-                    return multipart["\(int)"]
-                } else {
-                    return nil
-                }
-            }
-            
-            let form = try LoginForm(validating: postData)
-            XCTAssertEqual(form.username, "user1")
-        } catch { XCTFail() }
+      }
+      internal init(validatedData: [String: Node]) throws {
+        username = validatedData["username"]!.string!
+        password = validatedData["password"]!.string!
+      }
     }
-
+    // Try and log in incorrectly
+    do {
+      let boundary = "~~vapor-forms~~"
+      var body = "--" + boundary + "\r\n"
+      body += "Content-Disposition: form-data; name=\"username\"\r\n"
+      body += "\r\n"
+      body += "user1\r\n"
+      body += "--" + boundary + "\r\n"
+      body += "Content-Disposition: form-data; name=\"password\"\r\n"
+      body += "\r\n"
+      body += "notmypassword\r\n"
+      body += "--" + boundary + "\r\n"
+      let parsedBoundary = try Multipart.parseBoundary(contentType: "multipart/form-data; charset=utf-8; boundary=\(boundary)")
+      let multipart = Multipart.parse(body.bytes, boundary: parsedBoundary)
+      let postData = Content()
+      postData.append { (indexes: [PathIndex]) -> Polymorphic? in
+        guard let first = indexes.first else { return nil }
+        if let string = first as? String {
+          return multipart[string]
+        } else if let int = first as? Int {
+          return multipart["\(int)"]
+        } else {
+          return nil
+        }
+      }
+      let _ = try LoginForm(validating: postData)
+      XCTFail()
+    } catch FormError.validationFailed(let fieldset) {
+      XCTAssertEqual(fieldset.errors["password"][0].localizedDescription, "Invalid password")
+    } catch { XCTFail() }
+    // Try and log in correctly
+    do {
+      let boundary = "~~vapor-forms~~"
+      var body = "--" + boundary + "\r\n"
+      body += "Content-Disposition: form-data; name=\"username\"\r\n"
+      body += "\r\n"
+      body += "user1\r\n"
+      body += "--" + boundary + "\r\n"
+      body += "Content-Disposition: form-data; name=\"password\"\r\n"
+      body += "\r\n"
+      body += "pass1\r\n"
+      body += "--" + boundary + "\r\n"
+      let parsedBoundary = try Multipart.parseBoundary(contentType: "multipart/form-data; charset=utf-8; boundary=\(boundary)")
+      let multipart = Multipart.parse(body.bytes, boundary: parsedBoundary)
+      let postData = Content()
+      postData.append { (indexes: [PathIndex]) -> Polymorphic? in
+        guard let first = indexes.first else { return nil }
+        if let string = first as? String {
+          return multipart[string]
+        } else if let int = first as? Int {
+          return multipart["\(int)"]
+        } else {
+          return nil
+        }
+      }
+      let form = try LoginForm(validating: postData)
+      XCTAssertEqual(form.username, "user1")
+    } catch { XCTFail() }
+  }
 }

--- a/Tests/VaporFormsTests/VaporFormsTests.swift
+++ b/Tests/VaporFormsTests/VaporFormsTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import VaporForms
-import Vapor
+@testable import Vapor
 import Leaf
 
 /**
@@ -65,6 +65,7 @@ class VaporFormsTests: XCTestCase {
       ("testWholeFieldsetUsage", testWholeFieldsetUsage),
       ("testWholeFormUsage", testWholeFormUsage),
       ("testSampleLoginForm", testSampleLoginForm),
+      ("testSampleLoginFormWithMultipart", testSampleLoginFormWithMultipart),
     ]
   }
 
@@ -700,5 +701,102 @@ class VaporFormsTests: XCTestCase {
       XCTAssertEqual(form.username, "user1")
     } catch { XCTFail() }
   }
+    
+    func testSampleLoginFormWithMultipart() {
+        // Test a simple login form which validates against a credential store.
+        struct LoginForm: Form {
+            let username: String
+            let password: String
+            static let fieldset = Fieldset([
+                "username": StringField(label: "Username"),
+                "password": StringField(label: "Password"),
+                ], requiring: ["username", "password"]) { fieldset in
+                    let credentialStore = [
+                        (username: "user1", password: "pass1"),
+                        (username: "user2", password: "pass2"),
+                        (username: "user3", password: "pass3"),
+                        ]
+                    if (credentialStore.filter {
+                        $0.username == fieldset.values["username"]!.string! && $0.password == fieldset.values["password"]!.string!
+                        }.isEmpty) {
+                        fieldset.errors["password"].append(FieldError.validationFailed(message: "Invalid password"))
+                    }
+            }
+            internal init(validatedData: [String: Node]) throws {
+                username = validatedData["username"]!.string!
+                password = validatedData["password"]!.string!
+            }
+        }
+        // Try and log in incorrectly
+        do {
+            
+            let boundary = "~~vapor-forms~~"
+            var body = "--" + boundary + "\r\n"
+            body += "Content-Disposition: form-data; name=\"username\"\r\n"
+            body += "\r\n"
+            body += "user1\r\n"
+            body += "--" + boundary + "\r\n"
+            body += "Content-Disposition: form-data; name=\"password\"\r\n"
+            body += "\r\n"
+            body += "notmypassword\r\n"
+            body += "--" + boundary + "\r\n"
+            
+            
+            let parsedBoundary = try Multipart.parseBoundary(contentType: "multipart/form-data; charset=utf-8; boundary=\(boundary)")
+            let multipart = Multipart.parse(body.bytes, boundary: parsedBoundary)
+            
+            let postData = Content()
+            
+            postData.append { (indexes: [PathIndex]) -> Polymorphic? in
+                guard let first = indexes.first else { return nil }
+                if let string = first as? String {
+                    return multipart[string]
+                } else if let int = first as? Int {
+                    return multipart["\(int)"]
+                } else {
+                    return nil
+                }
+            }
+            
+            let _ = try LoginForm(validating: postData)
+            XCTFail()
+        } catch FormError.validationFailed(let fieldset) {
+            XCTAssertEqual(fieldset.errors["password"][0].localizedDescription, "Invalid password")
+        } catch { XCTFail() }
+        // Try and log in correctly
+        do {
+            
+            let boundary = "~~vapor-forms~~"
+            var body = "--" + boundary + "\r\n"
+            body += "Content-Disposition: form-data; name=\"username\"\r\n"
+            body += "\r\n"
+            body += "user1\r\n"
+            body += "--" + boundary + "\r\n"
+            body += "Content-Disposition: form-data; name=\"password\"\r\n"
+            body += "\r\n"
+            body += "pass1\r\n"
+            body += "--" + boundary + "\r\n"
+            
+            
+            let parsedBoundary = try Multipart.parseBoundary(contentType: "multipart/form-data; charset=utf-8; boundary=\(boundary)")
+            let multipart = Multipart.parse(body.bytes, boundary: parsedBoundary)
+            
+            let postData = Content()
+            
+            postData.append { (indexes: [PathIndex]) -> Polymorphic? in
+                guard let first = indexes.first else { return nil }
+                if let string = first as? String {
+                    return multipart[string]
+                } else if let int = first as? Int {
+                    return multipart["\(int)"]
+                } else {
+                    return nil
+                }
+            }
+            
+            let form = try LoginForm(validating: postData)
+            XCTAssertEqual(form.username, "user1")
+        } catch { XCTFail() }
+    }
 
 }


### PR DESCRIPTION
While sending API calls using form-data, I was noticing the required fields were always triggering even though I was sure that they were there. They are handled as Multipart and there was only a check for Node. 

Added a support for Multipart strings (missing file functionality) and test to confirm it's now working.