### PR TITLE
Add Multipart support for fields

### DIFF
--- a/Sources/VaporForms/Fieldset.swift
+++ b/Sources/VaporForms/Fieldset.swift
@@ -72,6 +72,8 @@ public struct Fieldset {
           return
         }
         value = Node(fieldString)
+      } else if let multipart = content[fieldName]?.string {
+        value = Node(multipart)
       } else {
         performRequiredFieldCheck(for: fieldName)
         return


### PR DESCRIPTION
I was trying to use vapor-forms in a multipart post request, using it for everything except the actual uploaded file (handled that on my own).
I don't know why, but if the form is posted as multipart, none of the fieldset parsers actually see any content.

`content[fieldName] as? Node` returns nil.
But somehow, `content[fieldName]?.string` returns a valid string.

This PR checks for that form of parsing as well.